### PR TITLE
Fix Windows CI: link leaf example against odelia library

### DIFF
--- a/tests/testthat/helper-load-odelia.R
+++ b/tests/testthat/helper-load-odelia.R
@@ -1,6 +1,7 @@
 .odelia_test_cache <- new.env(parent = emptyenv())
 .odelia_test_cache$ode_loaded <- FALSE
 .odelia_test_cache$leaf_loaded <- FALSE
+.odelia_test_cache$odelia_so <- NA_character_
 
 resolve_test_path <- function(installed_rel, source_rel) {
   pkg_path <- system.file(package = "odelia")
@@ -46,7 +47,11 @@ ensure_ode_interface_loaded <- function(rebuild = FALSE) {
     return(invisible(TRUE))
   }
 
-  testthat::expect_no_error(odelia_load_dll(local = FALSE, now = TRUE))
+  odelia_so <- NA_character_
+  testthat::expect_no_error(
+    odelia_so <- odelia_load_dll(local = FALSE, now = TRUE)
+  )
+  .odelia_test_cache$odelia_so <- odelia_so
 
   .odelia_test_cache$ode_loaded <- TRUE
   invisible(TRUE)
@@ -72,7 +77,30 @@ ensure_leaf_thermal_interfaces <- function(rebuild = FALSE) {
   )
 
   # Provide include paths needed by sourceCpp for package headers.
-  withr::local_envvar(PKG_CPPFLAGS = paste0("-I", include_dir))
+  #
+  # The XAD Tape<T,N> template methods are explicitly instantiated only in
+  # src/Tape.cpp, which is compiled into the odelia shared library. The leaf
+  # interface is built standalone by sourceCpp, so those symbols must be
+  # resolved against the odelia library. On Linux/macOS odelia_load_dll() makes
+  # them globally visible (RTLD_GLOBAL) and they resolve at load time, but
+  # Windows has no global symbol namespace - DLL imports must be resolved at
+  # link time. Linking the sourceCpp build directly against the odelia library
+  # via PKG_LIBS (honoured by R CMD SHLIB) works on every platform.
+  pkg_cppflags <- paste0("-I", include_dir)
+  odelia_so <- .odelia_test_cache$odelia_so
+  pkg_libs <- if (is.character(odelia_so) &&
+                  length(odelia_so) == 1 &&
+                  !is.na(odelia_so) &&
+                  nzchar(odelia_so) &&
+                  file.exists(odelia_so)) {
+    shQuote(normalizePath(odelia_so, winslash = "/", mustWork = FALSE))
+  } else {
+    Sys.getenv("PKG_LIBS", unset = "")
+  }
+  withr::local_envvar(
+    PKG_CPPFLAGS = pkg_cppflags,
+    PKG_LIBS = pkg_libs
+  )
 
   source_cpp_result <- tryCatch(
     {


### PR DESCRIPTION
## Problem

The Windows R-CMD-check job fails (`1 ERROR`) while running the leaf thermal tests. The `Rcpp::sourceCpp` build of `leaf_thermal_interface.cpp` fails at link time:

```
ld.exe: undefined reference to `xad::Tape<double, 1ull>::~Tape()'
ld.exe: undefined reference to `xad::Tape<double, 1ull>::newRecording()'
ld.exe: undefined reference to `xad::Tape<double, 1ull>::derivative(unsigned int)'
```

The XAD `Tape<T,N>` template methods are explicitly instantiated only in `src/Tape.cpp`, which compiles into the odelia shared library. The leaf example is built standalone, so those symbols must be resolved against odelia.

On Linux/macOS this works because `odelia_load_dll(local = FALSE)` loads odelia with `RTLD_GLOBAL`, so the leaf shared object's undefined references resolve at load time. **Windows has no global symbol namespace** — DLL imports must be resolved at *link* time — so `ld.exe` fails.

## Fix

Set `PKG_LIBS` (honoured by `R CMD SHLIB`, which `sourceCpp` uses) to the resolved odelia library path, so the leaf build links against odelia directly on every platform. The existing `RTLD_GLOBAL` path remains as a backstop on Unix.

## Notes

- The `checking pragmas` WARNING (from vendored `XAD/OperationsContainerPaired.hpp`) is left untouched — it's vendored upstream code, it does not fail CI (`error_on = "error"`), and R's pragma check is a textual grep that guards can't satisfy.
- Could not run the suite locally (unrelated vendored-XAD/libc++ incompatibility on the current macOS SDK); relying on CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)