### PR TITLE
Fix macOS build on libc++ 21 (XAD __promote class removed)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^LICENSE\.md$
 ^examples$
 ^docs$
+^tools$

--- a/inst/include/XAD/Literals.hpp
+++ b/inst/include/XAD/Literals.hpp
@@ -842,7 +842,15 @@ typedef ARealDirect<float, 1> AFD;
 }  // namespace xad
 
 
-#if __clang_major__ > 16 && defined(_LIBCPP_VERSION)
+// libc++ 21 (_LIBCPP_VERSION >= 210000) replaced the specializable `__promote`
+// class template with a SFINAE-friendly `__promote_t` alias built from
+// `__promote_impl` overloads. The alias is constrained to arithmetic types, so
+// std math overloads such as pow(AReal, int) now drop out of overload
+// resolution cleanly and XAD's own ADL overloads are selected without help.
+// The specializations below are therefore both unnecessary and ill-formed on
+// libc++ 21+, so we only emit them on older libc++ that still has the class.
+// odelia local patch: not yet fixed upstream (auto-differentiation/xad).
+#if __clang_major__ > 16 && defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 210000
 
 namespace std {
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,43 @@
+# Vendored XAD and local patches
+
+odelia vendors the [XAD](https://github.com/auto-differentiation/xad) automatic
+differentiation library:
+
+| Upstream                | In this package          |
+| ----------------------- | ------------------------ |
+| `src/XAD/*.hpp`         | `inst/include/XAD/*.hpp` |
+| `src/Tape.cpp`          | `src/Tape.cpp`           |
+
+Some headers (`Config.hpp`, `Version.hpp`, `Instantiations.hpp`) are **generated
+by XAD's CMake build**, so a faithful re-vendor is not a pure file copy — you
+must configure XAD with CMake once and copy the generated headers alongside the
+hand-written ones. The currently vendored snapshot is XAD `1.9.0-dev`.
+
+## Local patches
+
+We carry local fixes on top of the vendored snapshot, stored as `git apply`-able
+patches in [`patches/`](patches/):
+
+- **`0001-xad-libcxx21-promote-guard.patch`** — libc++ 21 (`_LIBCPP_VERSION >=
+  210000`) removed the specializable `std::__promote` class template that XAD
+  specializes in `Literals.hpp`, replacing it with a SFINAE-friendly
+  `__promote_t` alias. XAD's specializations are unnecessary and ill-formed
+  there, so the patch restricts them to `_LIBCPP_VERSION < 210000`. Not yet
+  fixed upstream — drop this patch once upstream handles the rename.
+
+## Re-vendoring workflow
+
+1. Copy the new upstream `src/XAD/*.hpp` + CMake-generated headers into
+   `inst/include/XAD/`, and `src/Tape.cpp` into `src/`.
+2. Re-apply the local patches:
+
+   ```sh
+   tools/apply-xad-patches.sh
+   ```
+
+3. Rebuild and test: `make test-installed`.
+
+Before relying on a patch, you can confirm it still applies to the freshly
+vendored sources with `tools/apply-xad-patches.sh --check`. If a patch no longer
+applies, upstream changed the relevant code — check whether the underlying issue
+is fixed upstream (in which case delete the patch) or re-create it.

--- a/tools/apply-xad-patches.sh
+++ b/tools/apply-xad-patches.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Re-apply odelia's local patches to the vendored XAD library.
+#
+# The XAD sources under inst/include/XAD/ and src/Tape.cpp are vendored from
+# https://github.com/auto-differentiation/xad. We carry a small number of local
+# patches on top of that snapshot (see tools/patches/ and tools/README.md).
+#
+# Run this after re-vendoring XAD so the local fixes are restored:
+#
+#   tools/apply-xad-patches.sh          # apply all patches
+#   tools/apply-xad-patches.sh --check  # dry-run; verify they still apply
+#
+# The script is safe to re-run: patches that are already applied are skipped.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+patch_dir="${repo_root}/tools/patches"
+
+cd "${repo_root}"
+
+check_only=0
+if [[ "${1:-}" == "--check" ]]; then
+  check_only=1
+fi
+
+shopt -s nullglob
+patches=("${patch_dir}"/*.patch)
+if [[ ${#patches[@]} -eq 0 ]]; then
+  echo "No patches found in ${patch_dir}"
+  exit 0
+fi
+
+for p in "${patches[@]}"; do
+  name="$(basename "${p}")"
+  if git apply --reverse --check "${p}" >/dev/null 2>&1; then
+    echo "skip   ${name} (already applied)"
+    continue
+  fi
+  if ! git apply --check "${p}" >/dev/null 2>&1; then
+    echo "FAIL   ${name} (does not apply cleanly - upstream likely changed; re-create the patch)" >&2
+    exit 1
+  fi
+  if [[ ${check_only} -eq 1 ]]; then
+    echo "ok     ${name} (would apply cleanly)"
+  else
+    git apply "${p}"
+    echo "apply  ${name}"
+  fi
+done
+
+echo "Done."

--- a/tools/patches/0001-xad-libcxx21-promote-guard.patch
+++ b/tools/patches/0001-xad-libcxx21-promote-guard.patch
@@ -1,0 +1,21 @@
+diff --git a/inst/include/XAD/Literals.hpp b/inst/include/XAD/Literals.hpp
+index 9f13c0d..5bdaaad 100644
+--- a/inst/include/XAD/Literals.hpp
++++ b/inst/include/XAD/Literals.hpp
+@@ -842,7 +842,15 @@ typedef ARealDirect<float, 1> AFD;
+ }  // namespace xad
+ 
+ 
+-#if __clang_major__ > 16 && defined(_LIBCPP_VERSION)
++// libc++ 21 (_LIBCPP_VERSION >= 210000) replaced the specializable `__promote`
++// class template with a SFINAE-friendly `__promote_t` alias built from
++// `__promote_impl` overloads. The alias is constrained to arithmetic types, so
++// std math overloads such as pow(AReal, int) now drop out of overload
++// resolution cleanly and XAD's own ADL overloads are selected without help.
++// The specializations below are therefore both unnecessary and ill-formed on
++// libc++ 21+, so we only emit them on older libc++ that still has the class.
++// odelia local patch: not yet fixed upstream (auto-differentiation/xad).
++#if __clang_major__ > 16 && defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 210000
+ 
+ namespace std {
+ 


### PR DESCRIPTION
## Problem

The package fails to compile locally on macOS with Apple clang 21 / libc++ 21 (`_LIBCPP_VERSION` 210106):

```
inst/include/XAD/Literals.hpp:905:7: error: no template named '__promote';
                                     did you mean '__promote_t'?
```

libc++ 21 removed the specializable `std::__promote` **class template** (it now survives only in the `__cxx03` variant) and replaced it with a SFINAE-friendly `__promote_t` alias built from overloaded `__promote_impl(...)` functions. The vendored XAD specializes the old class in `Literals.hpp` under `#if __clang_major__ > 16 && defined(_LIBCPP_VERSION)`, which is now:

- **unnecessary** — the new `__promote_t` is `enable_if`-constrained to arithmetic types, so `std::pow(AReal, int)` and friends drop out of overload resolution cleanly and XAD's own ADL overloads are selected; and
- **ill-formed** — there is no `__promote` class to specialize.

This is **not fixed upstream** (auto-differentiation/xad main, Feb 2026, still specializes the old class), so re-vendoring the latest XAD would not help.

## Fix

Restrict the specialization block to `_LIBCPP_VERSION < 210000`.

Because XAD is vendored (and some headers are CMake-generated, so re-vendoring isn't a pure copy), the fix is captured as a reusable patch so it survives re-vendoring:

- `tools/patches/0001-xad-libcxx21-promote-guard.patch`
- `tools/apply-xad-patches.sh` — re-applies local patches (`--check` to dry-run)
- `tools/README.md` — vendoring + patch workflow

## Verification

`R CMD INSTALL` and the full suite pass on Apple clang 21 / libc++ 21.0106:

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 155 ]
```

Older libc++ / libstdc++ (CI runners) keep the existing behaviour since the guard only narrows the libc++-21+ case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)